### PR TITLE
[POKEMON-0003] Create the WebServices Model

### DIFF
--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -9,12 +9,16 @@
 /* Begin PBXBuildFile section */
 		E018BC7E299C19A3000548E4 /* WebServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = E018BC7D299C19A3000548E4 /* WebServices.swift */; };
 		E03F6A682996887000367709 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03F6A672996887000367709 /* Pokemon.swift */; };
+		E08510C2299D568800DBD604 /* WebServicesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E08510C1299D568800DBD604 /* WebServicesTest.swift */; };
+		E08510C4299D5CD000DBD604 /* pichu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E08510C3299D5CD000DBD604 /* pichu_response.json */; };
 		E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F129957BB400F7CD13 /* AppDelegate.swift */; };
 		E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F329957BB400F7CD13 /* SceneDelegate.swift */; };
 		E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F529957BB400F7CD13 /* ViewController.swift */; };
 		E0C395F929957BB400F7CD13 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0C395F729957BB400F7CD13 /* Main.storyboard */; };
 		E0C395FB29957BB500F7CD13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FA29957BB500F7CD13 /* Assets.xcassets */; };
 		E0C395FE29957BB500F7CD13 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FC29957BB500F7CD13 /* LaunchScreen.storyboard */; };
+		E0C4ABCC299C0C00007A4D58 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C4ABCB299C0C00007A4D58 /* Network.swift */; };
+		E0C4ABCE299C0DBF007A4D58 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C4ABCD299C0DBF007A4D58 /* NetworkError.swift */; };
 		E0F0243B299BE4C700E83463 /* TypeElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243A299BE4C700E83463 /* TypeElement.swift */; };
 		E0F0243D299BE52000E83463 /* NameAndURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243C299BE52000E83463 /* NameAndURL.swift */; };
 		E0F0243F299BE56A00E83463 /* Ability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243E299BE56A00E83463 /* Ability.swift */; };
@@ -22,8 +26,6 @@
 		E0F02443299BE62600E83463 /* Move.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02442299BE62600E83463 /* Move.swift */; };
 		E0F02458299BE69000E83463 /* PokemonModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02457299BE69000E83463 /* PokemonModelTests.swift */; };
 		E0F0245F299BE6B100E83463 /* pikachu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E0F0245E299BE6B100E83463 /* pikachu_response.json */; };
-		E0C4ABCC299C0C00007A4D58 /* Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C4ABCB299C0C00007A4D58 /* Network.swift */; };
-		E0C4ABCE299C0DBF007A4D58 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C4ABCD299C0DBF007A4D58 /* NetworkError.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +41,8 @@
 /* Begin PBXFileReference section */
 		E018BC7D299C19A3000548E4 /* WebServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServices.swift; sourceTree = "<group>"; };
 		E03F6A672996887000367709 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
+		E08510C1299D568800DBD604 /* WebServicesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServicesTest.swift; sourceTree = "<group>"; };
+		E08510C3299D5CD000DBD604 /* pichu_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = pichu_response.json; path = ../../../../Desktop/pichu_response.json; sourceTree = "<group>"; };
 		E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokemonRampUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0C395F129957BB400F7CD13 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E0C395F329957BB400F7CD13 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -130,7 +134,9 @@
 			isa = PBXGroup;
 			children = (
 				E0F0245E299BE6B100E83463 /* pikachu_response.json */,
+				E08510C3299D5CD000DBD604 /* pichu_response.json */,
 				E0F02457299BE69000E83463 /* PokemonModelTests.swift */,
+				E08510C1299D568800DBD604 /* WebServicesTest.swift */,
 			);
 			path = PokemonRampUpTests;
 			sourceTree = "<group>";
@@ -226,6 +232,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E08510C4299D5CD000DBD604 /* pichu_response.json in Resources */,
 				E0F0245F299BE6B100E83463 /* pikachu_response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -256,6 +263,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E08510C2299D568800DBD604 /* WebServicesTest.swift in Sources */,
 				E0F02458299BE69000E83463 /* PokemonModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		E0C395FB29957BB500F7CD13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FA29957BB500F7CD13 /* Assets.xcassets */; };
 		E0C395FE29957BB500F7CD13 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FC29957BB500F7CD13 /* LaunchScreen.storyboard */; };
 		E0F0243B299BE4C700E83463 /* TypeElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243A299BE4C700E83463 /* TypeElement.swift */; };
-		E0F0243D299BE52000E83463 /* Species.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243C299BE52000E83463 /* Species.swift */; };
+		E0F0243D299BE52000E83463 /* NameAndURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243C299BE52000E83463 /* NameAndURL.swift */; };
 		E0F0243F299BE56A00E83463 /* Ability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243E299BE56A00E83463 /* Ability.swift */; };
 		E0F02441299BE5B500E83463 /* Sprites.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02440299BE5B500E83463 /* Sprites.swift */; };
 		E0F02443299BE62600E83463 /* Move.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02442299BE62600E83463 /* Move.swift */; };
@@ -44,7 +44,7 @@
 		E0C395FD29957BB500F7CD13 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E0C395FF29957BB500F7CD13 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E0F0243A299BE4C700E83463 /* TypeElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeElement.swift; sourceTree = "<group>"; };
-		E0F0243C299BE52000E83463 /* Species.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Species.swift; sourceTree = "<group>"; };
+		E0F0243C299BE52000E83463 /* NameAndURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameAndURL.swift; sourceTree = "<group>"; };
 		E0F0243E299BE56A00E83463 /* Ability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ability.swift; sourceTree = "<group>"; };
 		E0F02440299BE5B500E83463 /* Sprites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sprites.swift; sourceTree = "<group>"; };
 		E0F02442299BE62600E83463 /* Move.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Move.swift; sourceTree = "<group>"; };
@@ -76,7 +76,7 @@
 			children = (
 				E03F6A672996887000367709 /* Pokemon.swift */,
 				E0F0243A299BE4C700E83463 /* TypeElement.swift */,
-				E0F0243C299BE52000E83463 /* Species.swift */,
+				E0F0243C299BE52000E83463 /* NameAndURL.swift */,
 				E0F0243E299BE56A00E83463 /* Ability.swift */,
 				E0F02440299BE5B500E83463 /* Sprites.swift */,
 				E0F02442299BE62600E83463 /* Move.swift */,
@@ -235,7 +235,7 @@
 				E03F6A682996887000367709 /* Pokemon.swift in Sources */,
 				E0F0243F299BE56A00E83463 /* Ability.swift in Sources */,
 				E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */,
-				E0F0243D299BE52000E83463 /* Species.swift in Sources */,
+				E0F0243D299BE52000E83463 /* NameAndURL.swift in Sources */,
 				E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -14,7 +14,24 @@
 		E0C395F929957BB400F7CD13 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0C395F729957BB400F7CD13 /* Main.storyboard */; };
 		E0C395FB29957BB500F7CD13 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FA29957BB500F7CD13 /* Assets.xcassets */; };
 		E0C395FE29957BB500F7CD13 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E0C395FC29957BB500F7CD13 /* LaunchScreen.storyboard */; };
+		E0F0243B299BE4C700E83463 /* TypeElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243A299BE4C700E83463 /* TypeElement.swift */; };
+		E0F0243D299BE52000E83463 /* Species.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243C299BE52000E83463 /* Species.swift */; };
+		E0F0243F299BE56A00E83463 /* Ability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F0243E299BE56A00E83463 /* Ability.swift */; };
+		E0F02441299BE5B500E83463 /* Sprites.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02440299BE5B500E83463 /* Sprites.swift */; };
+		E0F02443299BE62600E83463 /* Move.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02442299BE62600E83463 /* Move.swift */; };
+		E0F02458299BE69000E83463 /* PokemonModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0F02457299BE69000E83463 /* PokemonModelTests.swift */; };
+		E0F0245F299BE6B100E83463 /* pikachu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E0F0245E299BE6B100E83463 /* pikachu_response.json */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E0F02459299BE69000E83463 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E0C395E629957BB400F7CD13 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E0C395ED29957BB400F7CD13;
+			remoteInfo = PokemonRampUp;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		E03F6A672996887000367709 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
@@ -26,10 +43,25 @@
 		E0C395FA29957BB500F7CD13 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E0C395FD29957BB500F7CD13 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		E0C395FF29957BB500F7CD13 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E0F0243A299BE4C700E83463 /* TypeElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeElement.swift; sourceTree = "<group>"; };
+		E0F0243C299BE52000E83463 /* Species.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Species.swift; sourceTree = "<group>"; };
+		E0F0243E299BE56A00E83463 /* Ability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ability.swift; sourceTree = "<group>"; };
+		E0F02440299BE5B500E83463 /* Sprites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sprites.swift; sourceTree = "<group>"; };
+		E0F02442299BE62600E83463 /* Move.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Move.swift; sourceTree = "<group>"; };
+		E0F02455299BE69000E83463 /* PokemonRampUpTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PokemonRampUpTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0F02457299BE69000E83463 /* PokemonModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonModelTests.swift; sourceTree = "<group>"; };
+		E0F0245E299BE6B100E83463 /* pikachu_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = pikachu_response.json; path = ../../../../Desktop/pikachu_response.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		E0C395EB29957BB400F7CD13 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E0F02452299BE69000E83463 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -43,6 +75,11 @@
 			isa = PBXGroup;
 			children = (
 				E03F6A672996887000367709 /* Pokemon.swift */,
+				E0F0243A299BE4C700E83463 /* TypeElement.swift */,
+				E0F0243C299BE52000E83463 /* Species.swift */,
+				E0F0243E299BE56A00E83463 /* Ability.swift */,
+				E0F02440299BE5B500E83463 /* Sprites.swift */,
+				E0F02442299BE62600E83463 /* Move.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -51,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				E0C395F029957BB400F7CD13 /* PokemonRampUp */,
+				E0F02456299BE69000E83463 /* PokemonRampUpTests */,
 				E0C395EF29957BB400F7CD13 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -59,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */,
+				E0F02455299BE69000E83463 /* PokemonRampUpTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -76,6 +115,15 @@
 				E0C395FF29957BB500F7CD13 /* Info.plist */,
 			);
 			path = PokemonRampUp;
+			sourceTree = "<group>";
+		};
+		E0F02456299BE69000E83463 /* PokemonRampUpTests */ = {
+			isa = PBXGroup;
+			children = (
+				E0F0245E299BE6B100E83463 /* pikachu_response.json */,
+				E0F02457299BE69000E83463 /* PokemonModelTests.swift */,
+			);
+			path = PokemonRampUpTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -98,6 +146,24 @@
 			productReference = E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		E0F02454299BE69000E83463 /* PokemonRampUpTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E0F0245B299BE69000E83463 /* Build configuration list for PBXNativeTarget "PokemonRampUpTests" */;
+			buildPhases = (
+				E0F02451299BE69000E83463 /* Sources */,
+				E0F02452299BE69000E83463 /* Frameworks */,
+				E0F02453299BE69000E83463 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E0F0245A299BE69000E83463 /* PBXTargetDependency */,
+			);
+			name = PokemonRampUpTests;
+			productName = PokemonRampUpTests;
+			productReference = E0F02455299BE69000E83463 /* PokemonRampUpTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -110,6 +176,10 @@
 				TargetAttributes = {
 					E0C395ED29957BB400F7CD13 = {
 						CreatedOnToolsVersion = 14.1;
+					};
+					E0F02454299BE69000E83463 = {
+						CreatedOnToolsVersion = 14.1;
+						TestTargetID = E0C395ED29957BB400F7CD13;
 					};
 				};
 			};
@@ -127,6 +197,7 @@
 			projectRoot = "";
 			targets = (
 				E0C395ED29957BB400F7CD13 /* PokemonRampUp */,
+				E0F02454299BE69000E83463 /* PokemonRampUpTests */,
 			);
 		};
 /* End PBXProject section */
@@ -142,6 +213,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E0F02453299BE69000E83463 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0F0245F299BE6B100E83463 /* pikachu_response.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -149,14 +228,35 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0F0243B299BE4C700E83463 /* TypeElement.swift in Sources */,
+				E0F02443299BE62600E83463 /* Move.swift in Sources */,
 				E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */,
+				E0F02441299BE5B500E83463 /* Sprites.swift in Sources */,
 				E03F6A682996887000367709 /* Pokemon.swift in Sources */,
+				E0F0243F299BE56A00E83463 /* Ability.swift in Sources */,
 				E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */,
+				E0F0243D299BE52000E83463 /* Species.swift in Sources */,
 				E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E0F02451299BE69000E83463 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E0F02458299BE69000E83463 /* PokemonModelTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E0F0245A299BE69000E83463 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E0C395ED29957BB400F7CD13 /* PokemonRampUp */;
+			targetProxy = E0F02459299BE69000E83463 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		E0C395F729957BB400F7CD13 /* Main.storyboard */ = {
@@ -346,6 +446,40 @@
 			};
 			name = Release;
 		};
+		E0F0245C299BE69000E83463 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.arriyam.pokemonrampup.PokemonRampUpTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokemonRampUp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PokemonRampUp";
+			};
+			name = Debug;
+		};
+		E0F0245D299BE69000E83463 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.arriyam.pokemonrampup.PokemonRampUpTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/PokemonRampUp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/PokemonRampUp";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -363,6 +497,15 @@
 			buildConfigurations = (
 				E0C3960329957BB500F7CD13 /* Debug */,
 				E0C3960429957BB500F7CD13 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E0F0245B299BE69000E83463 /* Build configuration list for PBXNativeTarget "PokemonRampUpTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0F0245C299BE69000E83463 /* Debug */,
+				E0F0245D299BE69000E83463 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E018BC7E299C19A3000548E4 /* WebServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = E018BC7D299C19A3000548E4 /* WebServices.swift */; };
 		E03F6A682996887000367709 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03F6A672996887000367709 /* Pokemon.swift */; };
 		E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F129957BB400F7CD13 /* AppDelegate.swift */; };
 		E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F329957BB400F7CD13 /* SceneDelegate.swift */; };
@@ -17,6 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		E018BC7D299C19A3000548E4 /* WebServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServices.swift; sourceTree = "<group>"; };
 		E03F6A672996887000367709 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
 		E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokemonRampUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0C395F129957BB400F7CD13 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -43,6 +45,7 @@
 			isa = PBXGroup;
 			children = (
 				E03F6A672996887000367709 /* Pokemon.swift */,
+				E018BC7D299C19A3000548E4 /* WebServices.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -150,6 +153,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */,
+				E018BC7E299C19A3000548E4 /* WebServices.swift in Sources */,
 				E03F6A682996887000367709 /* Pokemon.swift in Sources */,
 				E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */,
 				E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */,

--- a/PokemonRampUp/Model/Ability.swift
+++ b/PokemonRampUp/Model/Ability.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct Ability: Decodable {
-    let ability: Species
+    let ability: NameAndURL
     let isHidden: Bool
     let slot: Int
 
@@ -18,7 +18,7 @@ struct Ability: Decodable {
         case slot
     }
     
-    init(ability: Species,
+    init(ability: NameAndURL,
          isHidden: Bool,
          slot: Int
     ){

--- a/PokemonRampUp/Model/Ability.swift
+++ b/PokemonRampUp/Model/Ability.swift
@@ -1,0 +1,29 @@
+//
+//  Ability.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+struct Ability: Decodable {
+    let ability: Species
+    let isHidden: Bool
+    let slot: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ability
+        case isHidden = "is_hidden"
+        case slot
+    }
+    
+    init(ability: Species,
+         isHidden: Bool,
+         slot: Int
+    ){
+        self.ability = ability
+        self.isHidden = isHidden
+        self.slot = slot
+    }
+}

--- a/PokemonRampUp/Model/Move.swift
+++ b/PokemonRampUp/Model/Move.swift
@@ -1,0 +1,17 @@
+//
+//  Move.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+// MARK: - Move
+struct Move: Decodable {
+    let move: Species
+    
+    init(move: Species) {
+        self.move = move
+    }
+}

--- a/PokemonRampUp/Model/Move.swift
+++ b/PokemonRampUp/Model/Move.swift
@@ -9,9 +9,9 @@ import Foundation
 
 // MARK: - Move
 struct Move: Decodable {
-    let move: Species
+    let move: NameAndURL
     
-    init(move: Species) {
+    init(move: NameAndURL) {
         self.move = move
     }
 }

--- a/PokemonRampUp/Model/NameAndURL.swift
+++ b/PokemonRampUp/Model/NameAndURL.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// This is a generic cstruct that has a name and URL variable. This is generic as there is many cases where this object is found when requesting Pokemon JSON from PokeAPI
-struct Species: Decodable {
+// This is a generic struct that has a name and URL variable. This is generic as there is many cases where this object is found when requesting Pokemon JSON from PokeAPI
+struct NameAndURL: Decodable {
     let name: String
     let url: String
     

--- a/PokemonRampUp/Model/Pokemon.swift
+++ b/PokemonRampUp/Model/Pokemon.swift
@@ -8,27 +8,24 @@
 import Foundation
 import UIKit
 
-struct Pokemon {
+// MARK: - Pokemon
+struct Pokemon: Decodable {
     let name: String
-    let type: String
-    let hiddenAbilites: [String]
-    let image: UIImage
-    let moves: [String]
+    let types: [TypeElement]
+    let abilities: [Ability]
+    let sprites: Sprites
+    let moves: [Move]
     
-    //
-    // MARK: - Initialization
-    //
     init(name: String,
-         type: String,
-         hiddenAbilites: [String],
-         image: UIImage,
-         moves: [String]
+         types: [TypeElement],
+         abilities: [Ability],
+         sprites: Sprites,
+         moves: [Move]
     ){
         self.name = name
-        self.type = type
-        self.hiddenAbilites = hiddenAbilites
-        self.image = image
+        self.types = types
+        self.abilities = abilities
+        self.sprites = sprites
         self.moves = moves
     }
-    
 }

--- a/PokemonRampUp/Model/Species.swift
+++ b/PokemonRampUp/Model/Species.swift
@@ -1,0 +1,23 @@
+//
+//  Species.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+// This is a generic cstruct that has a name and URL variable. This is generic as there is many cases where this object is found when requesting Pokemon JSON from PokeAPI
+struct Species: Decodable {
+    let name: String
+    let url: String
+    
+    init(name: String,
+         url: String
+    ){
+        self.name = name
+        self.url = url
+    }
+}
+
+

--- a/PokemonRampUp/Model/Sprites.swift
+++ b/PokemonRampUp/Model/Sprites.swift
@@ -7,28 +7,27 @@
 
 import Foundation
 
-class Sprites: Decodable {
-    let backDefault, backFemale, backShiny, backShinyFemale, frontDefault, frontFemale, frontShiny, frontShinyFemale: String?
+// Sprites struct represents multiple properties that contain URL's that direct to Pokemon images
+struct Sprites: Decodable {
+    // There are multiple properties to make sure that atleast one of the poperties is vaild(not nil).
+    let frontDefaultUrl: String?
+    let frontShinyUrl: String?
+    let frontDreamWorldUrl: String?
 
     enum CodingKeys: String, CodingKey {
-        case backDefault = "back_default"
-        case backFemale = "back_female"
-        case backShiny = "back_shiny"
-        case backShinyFemale = "back_shiny_female"
-        case frontDefault = "front_default"
-        case frontFemale = "front_female"
-        case frontShiny = "front_shiny"
-        case frontShinyFemale = "front_shiny_female"
+        case frontDefaultUrl, frontDreamWorldUrl = "front_default"
+        case frontShinyUrl = "front_shiny"
+        case other
+        case dreamWorld = "dream_world"
     }
 
-    init(backDefault: String, backFemale: String, backShiny: String, backShinyFemale: String, frontDefault: String, frontFemale: String, frontShiny: String, frontShinyFemale: String) {
-        self.backDefault = backDefault
-        self.backFemale = backFemale
-        self.backShiny = backShiny
-        self.backShinyFemale = backShinyFemale
-        self.frontDefault = frontDefault
-        self.frontFemale = frontFemale
-        self.frontShiny = frontShiny
-        self.frontShinyFemale = frontShinyFemale
+    // Custom decoder init block to work with nested JSON objects
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.frontDefaultUrl = try container.decodeIfPresent(String.self, forKey: .frontDefaultUrl)
+        self.frontShinyUrl = try container.decodeIfPresent(String.self, forKey: .frontShinyUrl)
+        let otherContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .other)
+        let dreamWorldContainer = try otherContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .dreamWorld)
+        self.frontDreamWorldUrl = try dreamWorldContainer.decodeIfPresent(String.self, forKey: .frontDreamWorldUrl)
     }
 }

--- a/PokemonRampUp/Model/Sprites.swift
+++ b/PokemonRampUp/Model/Sprites.swift
@@ -8,8 +8,7 @@
 import Foundation
 
 class Sprites: Decodable {
-    let backDefault, backFemale, backShiny, backShinyFemale: String
-    let frontDefault, frontFemale, frontShiny, frontShinyFemale: String
+    let backDefault, backFemale, backShiny, backShinyFemale, frontDefault, frontFemale, frontShiny, frontShinyFemale: String?
 
     enum CodingKeys: String, CodingKey {
         case backDefault = "back_default"

--- a/PokemonRampUp/Model/Sprites.swift
+++ b/PokemonRampUp/Model/Sprites.swift
@@ -1,0 +1,35 @@
+//
+//  Sprites.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+class Sprites: Decodable {
+    let backDefault, backFemale, backShiny, backShinyFemale: String
+    let frontDefault, frontFemale, frontShiny, frontShinyFemale: String
+
+    enum CodingKeys: String, CodingKey {
+        case backDefault = "back_default"
+        case backFemale = "back_female"
+        case backShiny = "back_shiny"
+        case backShinyFemale = "back_shiny_female"
+        case frontDefault = "front_default"
+        case frontFemale = "front_female"
+        case frontShiny = "front_shiny"
+        case frontShinyFemale = "front_shiny_female"
+    }
+
+    init(backDefault: String, backFemale: String, backShiny: String, backShinyFemale: String, frontDefault: String, frontFemale: String, frontShiny: String, frontShinyFemale: String) {
+        self.backDefault = backDefault
+        self.backFemale = backFemale
+        self.backShiny = backShiny
+        self.backShinyFemale = backShinyFemale
+        self.frontDefault = frontDefault
+        self.frontFemale = frontFemale
+        self.frontShiny = frontShiny
+        self.frontShinyFemale = frontShinyFemale
+    }
+}

--- a/PokemonRampUp/Model/TypeElement.swift
+++ b/PokemonRampUp/Model/TypeElement.swift
@@ -9,13 +9,9 @@ import Foundation
 
 // MARK: - TypeElement
 struct TypeElement: Decodable {
-    let slot: Int
-    let type: Species
+    let type: NameAndURL
     
-    init(slot: Int,
-         type: Species
-    ){
-        self.slot = slot
+    init(type: NameAndURL){
         self.type = type
     }
 }

--- a/PokemonRampUp/Model/TypeElement.swift
+++ b/PokemonRampUp/Model/TypeElement.swift
@@ -1,0 +1,21 @@
+//
+//  TypeElement.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+// MARK: - TypeElement
+struct TypeElement: Decodable {
+    let slot: Int
+    let type: Species
+    
+    init(slot: Int,
+         type: Species
+    ){
+        self.slot = slot
+        self.type = type
+    }
+}

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -17,7 +17,7 @@ class WebServices {
     
     //Returns a number from 1 to 1008(inclusive). The number is an Id which is used to fetch a random Pokemon from PokeAPI
     func randomIdGenerator() -> Int{
-        return Int.random(in: 1..<1009)
+        return Int.random(in: 1...1008)
     }
     
     func fetchRandomPokemon() async throws -> Pokemon {

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -14,8 +14,15 @@ class WebServices {
         return Int.random(in: 1..<1009)
     }
     
-//    func fetchRandomPokemon() -> Pokemon{
-//
-//    }
+    func fetchRandomPokemon() -> Pokemon?{
+        let pokeApiBaseUrlString = "https://pokeapi.co/api/v2/pokemon/"
+        let randomPokemonId = randomIdGenerator()
+        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
+        
+//        let pokemon = DefaultNetwork().loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon)
+        
+        return nil
+        
+    }
     
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -9,20 +9,23 @@ import Foundation
 
 class WebServices {
     
+    let network: Network
+    
+    init(network: Network = DefaultNetwork()) {
+        self.network = network
+    }
+    
     //Returns a number from 1 to 1008(inclusive). The number is an Id which is used to fetch a random Pokemon from PokeAPI
     func randomIdGenerator() -> Int{
         return Int.random(in: 1..<1009)
     }
     
-    func fetchRandomPokemon() -> Pokemon?{
-        let pokeApiBaseUrlString = "https://pokeapi.co/api/v2/pokemon/"
+    func fetchRandomPokemon() async throws -> Pokemon {
         let randomPokemonId = randomIdGenerator()
-        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
-        
-//        let pokemon = DefaultNetwork().loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon)
-        
-        return nil
-        
+//        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
+        let uniquePokemonUrl =  "https://pokeapi.co/api/v2/pokemon/pichu/"
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        return randomPokemon
     }
     
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -32,4 +32,10 @@ class WebServices {
         let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
         return randomPokemon
     }
+    
+    func fetchPokemon(pokemonName: String) async throws -> Pokemon {
+        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonName)"
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        return randomPokemon
+    }
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -22,10 +22,14 @@ class WebServices {
     
     func fetchRandomPokemon() async throws -> Pokemon {
         let randomPokemonId = randomIdGenerator()
-//        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
-        let uniquePokemonUrl =  "https://pokeapi.co/api/v2/pokemon/pichu/"
+        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
         let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
         return randomPokemon
     }
     
+    func fetchPokemon(pokemonId: Int) async throws -> Pokemon {
+        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonId)"
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        return randomPokemon
+    }
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -1,0 +1,21 @@
+//
+//  WebServices.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import Foundation
+
+class WebServices {
+    
+    //Returns a number from 1 to 1008(inclusive). The number is an Id which is used to fetch a random Pokemon from PokeAPI
+    func randomIdGenerator() -> Int{
+        return Int.random(in: 1..<1009)
+    }
+    
+//    func fetchRandomPokemon() -> Pokemon{
+//
+//    }
+    
+}

--- a/PokemonRampUpTests/PokemonModelTests.swift
+++ b/PokemonRampUpTests/PokemonModelTests.swift
@@ -1,0 +1,33 @@
+//
+//  PokemonRampUpTests.swift
+//  PokemonRampUpTests
+//
+//  Created by Thushen Mohanarajah on 2023-02-14.
+//
+
+import XCTest
+@testable import PokemonRampUp
+
+// TO-DO [POKEMON-0011] Create unit test for Pokemon Model
+final class PokemonModelTests: XCTestCase {
+
+    //NOTE: This test is to sure the Pokemon Model works as intended. Will come back later in TO-DO [POKEMON-0011] to complete all unit tests for this model
+    func testPokemonModelDecoding() {
+        let bundle = Bundle(for: type(of: self))
+        guard let url = bundle.url(forResource: "pikachu_response", withExtension: "json"),
+            let data = try? Data(contentsOf: url) else {
+                return
+        }
+        
+        let decoder = JSONDecoder()
+
+        guard let pikachu = try? decoder.decode(Pokemon.self, from: data) else {
+            print("Failed")
+            return
+        }
+        
+        XCTAssertEqual(pikachu.name, "pikachu")
+        print("Successfully converted JSON to Pokemon Model")
+    }
+
+}

--- a/PokemonRampUpTests/WebServicesTest.swift
+++ b/PokemonRampUpTests/WebServicesTest.swift
@@ -30,5 +30,21 @@ final class WebServicesTest: XCTestCase {
             print("Failed to grab Pokemon from PokeAPI: unknown")
         }
     }
+    
+//  Test to see if all 1008 Pokemon Jsons can be modeled to the Pokemon class
+    func testfetchAllPokemon() async {
+        for i in 1...1008{
+            do {
+                let pokemon = try await WebServices().fetchPokemon(pokemonId: i)
+                print("Pokemon \(i): \(pokemon.name)")
+                
+            }
+            catch{
+                print("Failed to grab Pokemon from PokeAPI: unknown")
+                return
+            }
+        }
+        print("All Pokemon works!")
+    }
 
 }

--- a/PokemonRampUpTests/WebServicesTest.swift
+++ b/PokemonRampUpTests/WebServicesTest.swift
@@ -1,0 +1,34 @@
+//
+//  WebServicesTest.swift
+//  PokemonRampUpTests
+//
+//  Created by Thushen Mohanarajah on 2023-02-15.
+//
+import XCTest
+@testable import PokemonRampUp
+
+// TO-DO [POKEMON-0011] Create unit test for Pokemon Model
+final class WebServicesTest: XCTestCase {
+
+    //NOTE: This test is to sure the Pokemon Model works as intended. Will come back later in TO-DO [POKEMON-0011] to complete all unit tests for this model
+    func testFetchingPokemon() async {
+        do {
+            let pokemon = try await WebServices().fetchRandomPokemon()
+            print("Pokemon: \(pokemon.name)")
+            
+        }
+        catch(NetworkError.invalidURL){
+            print("Failed to grab Pokemon from PokeAPI: invalidURL")
+        }
+        catch(NetworkError.dateParseError){
+            print("Failed to grab Pokemon from PokeAPI: dateParseError")
+        }
+        catch(NetworkError.requestError){
+            print("Failed to grab Pokemon from PokeAPI: requestError")
+        }
+        catch{
+            print("Failed to grab Pokemon from PokeAPI: unknown")
+        }
+    }
+
+}

--- a/PokemonRampUpTests/WebServicesTest.swift
+++ b/PokemonRampUpTests/WebServicesTest.swift
@@ -33,10 +33,10 @@ final class WebServicesTest: XCTestCase {
     
 //  Test to see if all 1008 Pokemon Jsons can be modeled to the Pokemon class
     func testfetchAllPokemon() async {
-        for i in 1...1008{
+        for pokemonId in 1...1008{
             do {
-                let pokemon = try await WebServices().fetchPokemon(pokemonId: i)
-                print("Pokemon \(i): \(pokemon.name)")
+                let pokemon = try await WebServices().fetchPokemon(pokemonId: pokemonId)
+                print("Pokemon \(pokemonId): \(pokemon.name)")
                 
             }
             catch{


### PR DESCRIPTION
## Details

Create `WebServices` model.

## Related Tickets

Ticket: [POKEMON-0003](https://trello.com/c/nHo60qFd/2-implement-pokemon-data-retrieval-and-model)
Epic ticket: [POKEMON](https://trello.com/b/nsSxCgvo/pokemon)
To-do ticket : [POKEMON-0013](https://trello.com/c/dqgUd3R6/6-unit-tests)

## Motivation and Context

The model is used to create a correct URL to retrieve a random Pokemon from [PokéAPI](https://pokeapi.co/). Also, it contains a helper function needed to randomize Pokemon fetched.