### PR TITLE
 [POKEMON-0004] Updated Pokemon Model Classes

### DIFF
--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -8,10 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		E03A2DD229A92717007EAA5D /* WebServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03A2DD129A92717007EAA5D /* WebServices.swift */; };
-		E03F6A682996887000367709 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03F6A672996887000367709 /* Pokemon.swift */; };
+		E03F6A682996887000367709 /* PokemonJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03F6A672996887000367709 /* PokemonJSON.swift */; };
 		E07445E229A7C8860035974E /* pikachu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E07445DF29A7C8860035974E /* pikachu_response.json */; };
 		E07445E329A7C8860035974E /* error_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E07445E029A7C8860035974E /* error_response.json */; };
 		E07445E429A7C8860035974E /* pichu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E07445E129A7C8860035974E /* pichu_response.json */; };
+		E09F54CE29AFD42A00E906C1 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54CD29AFD42A00E906C1 /* Pokemon.swift */; };
+		E09F54D029AFD45A00E906C1 /* Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54CF29AFD45A00E906C1 /* Images.swift */; };
 		E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F129957BB400F7CD13 /* AppDelegate.swift */; };
 		E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F329957BB400F7CD13 /* SceneDelegate.swift */; };
 		E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F529957BB400F7CD13 /* ViewController.swift */; };
@@ -39,10 +41,12 @@
 
 /* Begin PBXFileReference section */
 		E03A2DD129A92717007EAA5D /* WebServices.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebServices.swift; sourceTree = "<group>"; };
-		E03F6A672996887000367709 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
+		E03F6A672996887000367709 /* PokemonJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonJSON.swift; sourceTree = "<group>"; };
 		E07445DF29A7C8860035974E /* pikachu_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pikachu_response.json; sourceTree = "<group>"; };
 		E07445E029A7C8860035974E /* error_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = error_response.json; sourceTree = "<group>"; };
 		E07445E129A7C8860035974E /* pichu_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pichu_response.json; sourceTree = "<group>"; };
+		E09F54CD29AFD42A00E906C1 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
+		E09F54CF29AFD45A00E906C1 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
 		E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokemonRampUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0C395F129957BB400F7CD13 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E0C395F329957BB400F7CD13 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -82,14 +86,16 @@
 		E03F6A662996886600367709 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				E03A2DD129A92717007EAA5D /* WebServices.swift */,
-				E03F6A672996887000367709 /* Pokemon.swift */,
-				E0F02440299BE5B500E83463 /* Sprites.swift */,
+				E09F54CD29AFD42A00E906C1 /* Pokemon.swift */,
+				E03F6A672996887000367709 /* PokemonJSON.swift */,
 				E0F0243A299BE4C700E83463 /* ElementType.swift */,
 				E0F0243E299BE56A00E83463 /* Ability.swift */,
 				E0F02442299BE62600E83463 /* Move.swift */,
+				E0F02440299BE5B500E83463 /* Sprites.swift */,
+				E09F54CF29AFD45A00E906C1 /* Images.swift */,
 				E0C4ABCB299C0C00007A4D58 /* Network.swift */,
 				E0C4ABCD299C0DBF007A4D58 /* NetworkError.swift */,
+				E03A2DD129A92717007EAA5D /* WebServices.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -254,9 +260,11 @@
 				E0F02443299BE62600E83463 /* Move.swift in Sources */,
 				E0C4ABCC299C0C00007A4D58 /* Network.swift in Sources */,
 				E03A2DD229A92717007EAA5D /* WebServices.swift in Sources */,
+				E09F54D029AFD45A00E906C1 /* Images.swift in Sources */,
 				E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */,
+				E09F54CE29AFD42A00E906C1 /* Pokemon.swift in Sources */,
 				E0F02441299BE5B500E83463 /* Sprites.swift in Sources */,
-				E03F6A682996887000367709 /* Pokemon.swift in Sources */,
+				E03F6A682996887000367709 /* PokemonJSON.swift in Sources */,
 				E0F0243F299BE56A00E83463 /* Ability.swift in Sources */,
 				E0C4ABCE299C0DBF007A4D58 /* NetworkError.swift in Sources */,
 				E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */,

--- a/PokemonRampUp/Model/Images.swift
+++ b/PokemonRampUp/Model/Images.swift
@@ -1,0 +1,16 @@
+//
+//  Images.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-28.
+//
+
+import Foundation
+import UIKit
+
+// Images struct represents a Pokemon Images in UIImage Object
+struct Images {
+    let frontDefault: UIImage?
+    let frontShiny: UIImage?
+    let frontOfficialArtwork: UIImage?
+}

--- a/PokemonRampUp/Model/Pokemon.swift
+++ b/PokemonRampUp/Model/Pokemon.swift
@@ -2,24 +2,25 @@
 //  Pokemon.swift
 //  PokemonRampUp
 //
-//  Created by Thushen Mohanarajah on 2023-02-10.
+//  Created by Thushen Mohanarajah on 2023-02-28.
 //
 
 import Foundation
 
-// Pokemon struct represents a Pokemon
-struct Pokemon: Decodable {
+// Pokemon struct represents a Pokemon object for the presenation layer
+struct Pokemon {
     let name: String
     let elementTypes: [ElementType]
     let abilities: [Ability]
-    let sprites: Sprites
     let moves: [Move]
+    let images: Images
     
-    enum CodingKeys: String, CodingKey {
-        case name
-        case elementTypes = "types"
-        case abilities
-        case sprites
-        case moves
+    init(pokemonJSON: PokemonJSON, images: Images) {
+        self.name = pokemonJSON.name
+        self.elementTypes = pokemonJSON.elementTypes
+        self.abilities = pokemonJSON.abilities
+        self.moves = pokemonJSON.moves
+        self.images = images
     }
+    
 }

--- a/PokemonRampUp/Model/PokemonJSON.swift
+++ b/PokemonRampUp/Model/PokemonJSON.swift
@@ -1,0 +1,26 @@
+//
+//  PokemonJSON.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-02-10.
+//
+
+import Foundation
+
+// PokemonJSON struct represents a Pokemon object that is decodbale as this is a responce model
+struct PokemonJSON: Decodable {
+    let name: String
+    let elementTypes: [ElementType]
+    let abilities: [Ability]
+    let moves: [Move]
+    let sprites: Sprites
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case elementTypes = "types"
+        case abilities
+        case moves
+        case sprites
+    }
+}
+

--- a/PokemonRampUp/Model/Sprites.swift
+++ b/PokemonRampUp/Model/Sprites.swift
@@ -12,22 +12,22 @@ struct Sprites: Decodable {
     // There are multiple properties to make sure that atleast one of the poperties is vaild(not nil).
     let frontDefaultUrl: String?
     let frontShinyUrl: String?
-    let frontDreamWorldUrl: String?
+    let frontOfficialArtworkUrl: String?
     
     enum CodingKeys: String, CodingKey {
-        case frontDefaultUrl, frontDreamWorldUrl
-        case frontShinyUrl
+        case frontDefault, frontDreamWorld
+        case frontShiny
         case other
-        case dreamWorld
+        case officialArtwork = "official-artwork"
     }
     
     // Custom decoder init block to work with nested JSON objects
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.frontDefaultUrl = try container.decodeIfPresent(String.self, forKey: .frontDefaultUrl)
-        self.frontShinyUrl = try container.decodeIfPresent(String.self, forKey: .frontShinyUrl)
+        self.frontDefaultUrl = try container.decodeIfPresent(String.self, forKey: .frontDefault)
+        self.frontShinyUrl = try container.decodeIfPresent(String.self, forKey: .frontShiny)
         let otherContainer = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: .other)
-        let dreamWorldContainer = try otherContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .dreamWorld)
-        self.frontDreamWorldUrl = try dreamWorldContainer.decodeIfPresent(String.self, forKey: .frontDreamWorldUrl)
+        let dreamWorldContainer = try otherContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .officialArtwork)
+        self.frontOfficialArtworkUrl = try dreamWorldContainer.decodeIfPresent(String.self, forKey: .frontDreamWorld)
     }
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -21,22 +21,22 @@ class WebServices {
         return Int.random(in: 1...1008)
     }
 
-    func fetchRandomPokemon() async throws -> Pokemon {
+    func fetchRandomPokemon() async throws -> PokemonJSON {
         let randomPokemonId = randomIdGenerator()
         let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         return randomPokemon
     }
 
-    func fetchPokemon(pokemonId: Int) async throws -> Pokemon {
+    func fetchPokemon(pokemonId: Int) async throws -> PokemonJSON {
         let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonId)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         return randomPokemon
     }
 
-    func fetchPokemon(pokemonName: String) async throws -> Pokemon {
+    func fetchPokemon(pokemonName: String) async throws -> PokemonJSON {
         let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonName)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: Pokemon.self)
+        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         return randomPokemon
     }
 }

--- a/PokemonRampUpTests/PokemonModelTests.swift
+++ b/PokemonRampUpTests/PokemonModelTests.swift
@@ -23,7 +23,7 @@ final class PokemonModelTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         
         // When
-        guard let _ = try? decoder.decode(Pokemon.self, from: data) else {
+        guard let _ = try? decoder.decode(PokemonJSON.self, from: data) else {
             // Then
             XCTFail("JSON file should not fail to decode")
             return
@@ -42,7 +42,7 @@ final class PokemonModelTests: XCTestCase {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         
         // When
-        guard let _ = try? decoder.decode(Pokemon.self, from: data) else {
+        guard let _ = try? decoder.decode(PokemonJSON.self, from: data) else {
             return
         }
         


### PR DESCRIPTION
## Details

Update pure model `Pokemon` struct. Added other model classes such as `PokemonJSON` and `Images` class.
## Related Tickets

Ticket: [POKEMON-0000](https://trello.com/c/nHo60qFd/2-implement-pokemon-data-retrieval-and-model)
Epic ticket: [POKEMON](https://trello.com/b/nsSxCgvo/pokemon)
To-do ticket : [POKEMON-0011](https://trello.com/c/dqgUd3R6/6-unit-tests)


## Motivation and Context

It would be easier to display Pokemon images throughout the app if the `Pokemon` model stored UIImages instead of `Sprites`(URL links to images). Unfortunately, the `UIImage` object does not conform to decodable. So I created `PokemonJSON` as the response model which is decodable. The `PokemonJSON` response model will help create the `Pokemon` model which will be used in the presentation layer. Note: the `Pokemon` model will contain UIImage objects.