### PR TITLE
[POKEMON-0005] Updated Pokemon Model Classes

### DIFF
--- a/PokemonRampUp/Model/Network.swift
+++ b/PokemonRampUp/Model/Network.swift
@@ -4,12 +4,13 @@
 //
 //  Created by Thushen Mohanarajah on 2023-02-14.
 //
-
 import Foundation
+import UIKit
 
 // TO-DO [POKEMON-0012] Create unit test for Network model
 protocol Network {
     func loadJSONObject<T: Decodable>(stringURL: String, type: T.Type) async throws -> T
+    func loadUIImage(urlString: String?) async throws -> UIImage?
 }
 
 struct DefaultNetwork: Network {
@@ -36,4 +37,25 @@ struct DefaultNetwork: Network {
 
          return objectT
      }
+    
+    func loadUIImage(urlString: String?) async throws -> UIImage? {
+        if (urlString == nil){
+            return nil
+        }
+        guard let url = URL(string: urlString!) else {
+            throw NetworkError.invalidURL
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw NetworkError.invalidURL
+        }
+
+        guard let image = UIImage(data: data) else {
+            throw NetworkError.invaildImageData
+        }
+        return image
+    }
  }

--- a/PokemonRampUp/Model/NetworkError.swift
+++ b/PokemonRampUp/Model/NetworkError.swift
@@ -12,4 +12,5 @@ enum NetworkError: Error {
     case invalidURL
     case dateParseError
     case requestError
+    case invaildImageData
 }

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -4,39 +4,52 @@
 //
 //  Created by Thushen Mohanarajah on 2023-02-17.
 //
-
 import Foundation
+import UIKit
 
 // TO-DO [POKEMON-0013] Finish unit test for WebServices Model
 class WebServices {
 
     let network: Network
+    let pokemonUrl = "https://pokeapi.co/api/v2/pokemon/"
 
     init(network: Network = DefaultNetwork()) {
         self.network = network
     }
 
-    //Returns a number from 1 to 1008(inclusive). The number is an Id which is used to fetch a random Pokemon from PokeAPI
-    func randomIdGenerator() -> Int{
+    // Returns a number from 1 to 1008(inclusive). The number is an Id which is used to fetch a random Pokemon from PokeAPI
+    private func randomIdGenerator() -> Int {
         return Int.random(in: 1...1008)
     }
+    
+    private func fetchPokemonUIIamges(pokemonJSON: PokemonJSON) async throws -> Images{
+        async let frontDefaultImage = try network.loadUIImage(urlString: pokemonJSON.sprites.frontDefaultUrl)
+        async let frontShinyImage = try network.loadUIImage(urlString: pokemonJSON.sprites.frontShinyUrl)
+        async let frontOfficialArtworkImage = try network.loadUIImage(urlString: pokemonJSON.sprites.frontOfficialArtworkUrl)
+        return await Images(frontDefault: try frontDefaultImage, frontShiny: try frontShinyImage, frontOfficialArtwork: try frontOfficialArtworkImage)
+    }
 
-    func fetchRandomPokemon() async throws -> PokemonJSON {
-        let randomPokemonId = randomIdGenerator()
-        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(randomPokemonId)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
+    func fetchRandomPokemon() async throws -> Pokemon {
+        let uniquePokemonUrl = pokemonUrl + String(randomIdGenerator())
+        let randomPokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
+        let images = try await fetchPokemonUIIamges(pokemonJSON: randomPokemonJSON)
+        let randomPokemon = Pokemon(pokemonJSON: randomPokemonJSON, images: images)
         return randomPokemon
     }
 
-    func fetchPokemon(pokemonId: Int) async throws -> PokemonJSON {
-        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonId)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
+    func fetchPokemon(pokemonId: Int) async throws -> Pokemon {
+        let uniquePokemonUrl = pokemonUrl + String(pokemonId)
+        let randomPokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
+        let images = try await fetchPokemonUIIamges(pokemonJSON: randomPokemonJSON)
+        let randomPokemon = Pokemon(pokemonJSON: randomPokemonJSON, images: images)
         return randomPokemon
     }
 
-    func fetchPokemon(pokemonName: String) async throws -> PokemonJSON {
-        let uniquePokemonUrl = "https://pokeapi.co/api/v2/pokemon/\(pokemonName)"
-        let randomPokemon = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
-        return randomPokemon
+    func fetchPokemon(pokemonName: String) async throws -> Pokemon {
+        let uniquePokemonUrl = pokemonUrl + pokemonName
+        let pokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
+        let images = try await fetchPokemonUIIamges(pokemonJSON: pokemonJSON)
+        let pokemon = Pokemon(pokemonJSON: pokemonJSON, images: images)
+        return pokemon
     }
 }


### PR DESCRIPTION
## Details

Update models to handle image fetching. Also, can handle converting the image data to `UIImage `objects. 
## Related Tickets

Ticket: [POKEMON-0005](https://trello.com/c/nHo60qFd/2-implement-pokemon-data-retrieval-and-model)
Epic ticket: [POKEMON](https://trello.com/b/nsSxCgvo/pokemon)
To-do ticket : [POKEMON-0011](https://trello.com/c/dqgUd3R6/6-unit-tests)


## Motivation and Context

It would be easier to fetch and store images in the `Network` file. This implementation makes it easy to handle images throughout the app. Moreover, converting the decodable `PokemonJSON` object to a `Pokemon` object will happen in `Webservices`