### PR TITLE
[POKEMON-0007] Created PokemonJSONToPokemon Class

### DIFF
--- a/PokemonRampUp.xcodeproj/project.pbxproj
+++ b/PokemonRampUp.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		E07445E429A7C8860035974E /* pichu_response.json in Resources */ = {isa = PBXBuildFile; fileRef = E07445E129A7C8860035974E /* pichu_response.json */; };
 		E09F54CE29AFD42A00E906C1 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54CD29AFD42A00E906C1 /* Pokemon.swift */; };
 		E09F54D029AFD45A00E906C1 /* Images.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54CF29AFD45A00E906C1 /* Images.swift */; };
+		E09F54D829B0FD0D00E906C1 /* PokemonJSONToPokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54D729B0FD0D00E906C1 /* PokemonJSONToPokemon.swift */; };
+		E09F54DD29B0FF5200E906C1 /* NameContainerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09F54DC29B0FF5200E906C1 /* NameContainerProtocol.swift */; };
 		E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F129957BB400F7CD13 /* AppDelegate.swift */; };
 		E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F329957BB400F7CD13 /* SceneDelegate.swift */; };
 		E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C395F529957BB400F7CD13 /* ViewController.swift */; };
@@ -47,6 +49,8 @@
 		E07445E129A7C8860035974E /* pichu_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pichu_response.json; sourceTree = "<group>"; };
 		E09F54CD29AFD42A00E906C1 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
 		E09F54CF29AFD45A00E906C1 /* Images.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Images.swift; sourceTree = "<group>"; };
+		E09F54D729B0FD0D00E906C1 /* PokemonJSONToPokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PokemonJSONToPokemon.swift; sourceTree = "<group>"; };
+		E09F54DC29B0FF5200E906C1 /* NameContainerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameContainerProtocol.swift; sourceTree = "<group>"; };
 		E0C395EE29957BB400F7CD13 /* PokemonRampUp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PokemonRampUp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0C395F129957BB400F7CD13 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E0C395F329957BB400F7CD13 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +100,7 @@
 				E0C4ABCB299C0C00007A4D58 /* Network.swift */,
 				E0C4ABCD299C0DBF007A4D58 /* NetworkError.swift */,
 				E03A2DD129A92717007EAA5D /* WebServices.swift */,
+				E09F54D729B0FD0D00E906C1 /* PokemonJSONToPokemon.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -108,6 +113,14 @@
 				E07445E029A7C8860035974E /* error_response.json */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		E09F54DE29B0FF7C00E906C1 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				E09F54DC29B0FF5200E906C1 /* NameContainerProtocol.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		E0C395E529957BB400F7CD13 = {
@@ -131,6 +144,7 @@
 		E0C395F029957BB400F7CD13 /* PokemonRampUp */ = {
 			isa = PBXGroup;
 			children = (
+				E09F54DE29B0FF7C00E906C1 /* Protocol */,
 				E03F6A662996886600367709 /* Model */,
 				E0C395F129957BB400F7CD13 /* AppDelegate.swift */,
 				E0C395F329957BB400F7CD13 /* SceneDelegate.swift */,
@@ -260,12 +274,14 @@
 				E0F02443299BE62600E83463 /* Move.swift in Sources */,
 				E0C4ABCC299C0C00007A4D58 /* Network.swift in Sources */,
 				E03A2DD229A92717007EAA5D /* WebServices.swift in Sources */,
+				E09F54DD29B0FF5200E906C1 /* NameContainerProtocol.swift in Sources */,
 				E09F54D029AFD45A00E906C1 /* Images.swift in Sources */,
 				E0C395F629957BB400F7CD13 /* ViewController.swift in Sources */,
 				E09F54CE29AFD42A00E906C1 /* Pokemon.swift in Sources */,
 				E0F02441299BE5B500E83463 /* Sprites.swift in Sources */,
 				E03F6A682996887000367709 /* PokemonJSON.swift in Sources */,
 				E0F0243F299BE56A00E83463 /* Ability.swift in Sources */,
+				E09F54D829B0FD0D00E906C1 /* PokemonJSONToPokemon.swift in Sources */,
 				E0C4ABCE299C0DBF007A4D58 /* NetworkError.swift in Sources */,
 				E0C395F229957BB400F7CD13 /* AppDelegate.swift in Sources */,
 				E0C395F429957BB400F7CD13 /* SceneDelegate.swift in Sources */,

--- a/PokemonRampUp/Model/Ability.swift
+++ b/PokemonRampUp/Model/Ability.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 // Ability struct represents a Pokemon ability
-struct Ability: Decodable {
-    let name: String
+struct Ability: Decodable, NameContainerProtocol{
+    var name: String
     
     enum CodingKeys: String, CodingKey {
         case ability

--- a/PokemonRampUp/Model/ElementType.swift
+++ b/PokemonRampUp/Model/ElementType.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 // TypeElement struct represents a Pokemon type
-struct ElementType: Decodable {
-    let name: String
+struct ElementType: Decodable, NameContainerProtocol {
+    var name: String
     
     enum CodingKeys: String, CodingKey {
         case type

--- a/PokemonRampUp/Model/Move.swift
+++ b/PokemonRampUp/Model/Move.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 // Move struct represents a Pokemon move
-struct Move: Decodable {
-    let name: String
+struct Move: Decodable, NameContainerProtocol {
+    var name: String
     
     enum CodingKeys: String, CodingKey {
         case move

--- a/PokemonRampUp/Model/Pokemon.swift
+++ b/PokemonRampUp/Model/Pokemon.swift
@@ -14,13 +14,4 @@ struct Pokemon {
     let abilities: [Ability]
     let moves: [Move]
     let images: Images
-    
-    init(pokemonJSON: PokemonJSON, images: Images) {
-        self.name = pokemonJSON.name
-        self.elementTypes = pokemonJSON.elementTypes
-        self.abilities = pokemonJSON.abilities
-        self.moves = pokemonJSON.moves
-        self.images = images
-    }
-    
 }

--- a/PokemonRampUp/Model/PokemonJSONToPokemon.swift
+++ b/PokemonRampUp/Model/PokemonJSONToPokemon.swift
@@ -1,0 +1,47 @@
+//
+//  PokemonJSONToPokemon.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-03-02.
+//
+
+import Foundation
+
+// TO-DO [POKEMON-0014] Create unit test for PokemonJSONToPokemon
+class PokemonJSONToPokemon{
+    
+    let pokemonJSON: PokemonJSON
+    let images: Images
+    
+    init(pokemonJSON: PokemonJSON, images: Images) {
+        self.pokemonJSON = pokemonJSON
+        self.images = images
+    }
+    
+    private func capitalizeFirstLetterOfNameContainers(nameContainers: [NameContainerProtocol]) -> [NameContainerProtocol]{
+        var mutableNameContainers = nameContainers
+        let length = mutableNameContainers.count - 1
+        for i in  0...length {
+            mutableNameContainers[i].name = mutableNameContainers[i].name.capitalizingFirstLetter()
+        }
+        return mutableNameContainers
+    }
+    
+    func convert() -> Pokemon{
+        let name = pokemonJSON.name.capitalizingFirstLetter()
+        let elementTypes = capitalizeFirstLetterOfNameContainers(nameContainers: pokemonJSON.elementTypes) as! [ElementType]
+        let abilities = capitalizeFirstLetterOfNameContainers(nameContainers: pokemonJSON.abilities) as! [Ability]
+        let moves = capitalizeFirstLetterOfNameContainers(nameContainers: pokemonJSON.moves) as! [Move]
+        return Pokemon(name: name, elementTypes: elementTypes, abilities: abilities, moves: moves, images: self.images)
+    }
+}
+
+extension String {
+    func capitalizingFirstLetter() -> String {
+        return prefix(1).capitalized + dropFirst()
+    }
+
+    mutating func capitalizeFirstLetter() {
+        self = self.capitalizingFirstLetter()
+    }
+}

--- a/PokemonRampUp/Model/WebServices.swift
+++ b/PokemonRampUp/Model/WebServices.swift
@@ -33,7 +33,7 @@ class WebServices {
         let uniquePokemonUrl = pokemonUrl + String(randomIdGenerator())
         let randomPokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         let images = try await fetchPokemonUIIamges(pokemonJSON: randomPokemonJSON)
-        let randomPokemon = Pokemon(pokemonJSON: randomPokemonJSON, images: images)
+        let randomPokemon = PokemonJSONToPokemon(pokemonJSON: randomPokemonJSON, images: images).convert()
         return randomPokemon
     }
 
@@ -41,7 +41,7 @@ class WebServices {
         let uniquePokemonUrl = pokemonUrl + String(pokemonId)
         let randomPokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         let images = try await fetchPokemonUIIamges(pokemonJSON: randomPokemonJSON)
-        let randomPokemon = Pokemon(pokemonJSON: randomPokemonJSON, images: images)
+        let randomPokemon = PokemonJSONToPokemon(pokemonJSON: randomPokemonJSON, images: images).convert()
         return randomPokemon
     }
 
@@ -49,7 +49,7 @@ class WebServices {
         let uniquePokemonUrl = pokemonUrl + pokemonName
         let pokemonJSON: PokemonJSON = try await network.loadJSONObject(stringURL: uniquePokemonUrl, type: PokemonJSON.self)
         let images = try await fetchPokemonUIIamges(pokemonJSON: pokemonJSON)
-        let pokemon = Pokemon(pokemonJSON: pokemonJSON, images: images)
+        let pokemon = PokemonJSONToPokemon(pokemonJSON: pokemonJSON, images: images).convert()
         return pokemon
     }
 }

--- a/PokemonRampUp/Protocol/NameContainerProtocol.swift
+++ b/PokemonRampUp/Protocol/NameContainerProtocol.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// NameContainerProtocol is a protocol that will be used in TypeElement, Ability and Move
 protocol NameContainerProtocol{
-    var name: String { get set}
+    var name: String { get set }
 }

--- a/PokemonRampUp/Protocol/NameContainerProtocol.swift
+++ b/PokemonRampUp/Protocol/NameContainerProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  NameContainerProtcol.swift
+//  PokemonRampUp
+//
+//  Created by Thushen Mohanarajah on 2023-03-02.
+//
+
+import Foundation
+
+protocol NameContainerProtocol{
+    var name: String { get set}
+}


### PR DESCRIPTION
## Details

Created `PokemonJSONToPokemon` class.

## Related Tickets

Ticket: [POKEMON-0007](https://trello.com/c/nHo60qFd/2-implement-pokemon-data-retrieval-and-model)
Epic ticket: [POKEMON](https://trello.com/b/nsSxCgvo/pokemon)
To-do ticket : [POKEMON-0014](https://trello.com/c/dqgUd3R6/6-unit-tests)

## Motivation and Context

This is needed as the strings(ie: name, ability->name, move->name, elementType->name) returned from the PokiAPI were lower case for the first letter. `PokemonJSONToPokemon` made it easy to mutate the strings to make the first letter capital. 

Example:
`Pokemon pichu`

`pichu.name` = "pichu" when it should be "Pichu"
`pichu.move[0]` = "electricity" when it should be "Electricity"

This PR fixes this issue.
